### PR TITLE
Fix matching to include all versions of wikipedia

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,7 @@
     },
     "content_scripts":[
     	{
-    		"matches":["https://en.wikipedia.org/*"],
+    		"matches":["*://*.wikipedia.org/*"],
     		"js":["scripts/jquery.js", "scripts/function.js"],
     		"css":["style.css"],
     		"run_at":"document_end"


### PR DESCRIPTION
Before, it only matched the english https-version of wikipedia.
